### PR TITLE
Read map-row values in explicit column order (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes
 
 * 2.7.next in progress
+  * Address [#613](https://github.com/seancorfield/honeysql/issues/613) by reading values from hash map rows in the order of the explicit column list (`:insert-into` or `:columns`) when one is given, instead of the hash map's key order; convert tests that relied on literal hash map key order to use `array-map`; document the key-ordering caveat for `:values` and `:set`.
   * Performance improvements via PRs [#609](https://github.com/seancorfield/honeysql/pull/609), [#610](https://github.com/seancorfield/honeysql/pull/610), and [#611](https://github.com/seancorfield/honeysql/pull/611) from [@alexander-yakushev](https://github.com/alexander-yakushev).
   * Add Jolt to CI (tests against latest Jolt release).
   * Update dev/test deps.

--- a/doc/clause-reference.md
+++ b/doc/clause-reference.md
@@ -870,7 +870,9 @@ example above with `:insert-into`.
 ## set (ANSI)
 
 `:set` accepts a hash map of SQL entities and the values
-that they should be assigned. This precedence -- between
+that they should be assigned. The assignments are generated in the
+iteration order of the hash map, which is only predictable for an
+unmodified `array-map` (see the note under `:values` above). This precedence -- between
 `:columns` and `:from` -- corresponds to ANSI SQL which
 is correct for most databases. The MySQL dialect that
 HoneySQL 2.x supports has a different precedence (below).
@@ -1471,6 +1473,13 @@ the `VALUES` clause itself.
 ```clojure
 user=> (sql/format {:values [{:col-a 1 :col-b 2}]})
 ["(col_a, col_b) VALUES (?, ?)" 1 2]
+```
+
+> Note: when no column list is given, the column order is the iteration order of the first hash map's keys. That is only predictable for an unmodified `array-map` (small literal maps happen to iterate in insertion order on Clojure and ClojureScript, but that is an implementation detail, and other Clojure dialects may differ). If you need a specific column order with hash map rows, specify the columns explicitly, either in `:insert-into` or via `:columns`, and the values will be read from each row in that order (as of 2.7.next; previously the explicit column names were used but the values still followed the hash map's key order, which could put values in the wrong columns).
+
+```clojure
+user=> (sql/format {:insert-into [:table [:col-a :col-b]] :values [{:col-b 2 :col-a 1}]})
+["INSERT INTO table (col_a, col_b) VALUES (?, ?)" 1 2]
 ```
 
 In addition, all of the rows are augmented to have

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -1377,6 +1377,33 @@
                      (join ", " (map #(format-entity % {:drop-ns true})) cols)
                      ")"))]))))
 
+;; issue #613: explicit column order must win over map key order
+(defn- explicit-columns
+  "Return the explicit column list for the statement being formatted, if any:
+   the columns in `:insert-into [table [cols]]` (etc) take precedence over
+   a `:columns` clause. Returns nil when no explicit columns were given."
+  []
+  (let [table (or (clause-body :insert-into)
+                  (clause-body :patch-into)
+                  (clause-body :replace-into))
+        table (if (and (sequential? table) (map? (first table)))
+                (rest table)
+                table)
+        cols  (when (and (sequential? table) (sequential? (second table)))
+                (second table))]
+    (or (seq cols) (seq (clause-body :columns)))))
+
+(defn- row-key
+  "Given a row (hash map) and an explicit column, return the key in the row
+   that supplies that column's value: an exact match if present, otherwise
+   a key with the same name (so `:t/did` in the row satisfies `:did`)."
+  [row col]
+  (if (or (contains? row col) (not (ident? col)))
+    col
+    (let [n (name col)]
+      (or (some (fn [k] (when (and (ident? k) (= n (name k))) k)) (keys row))
+          col))))
+
 (defn- format-values [k xs]
   (let [{:keys [values-default-columns]} *options*
         first-xs (when (sequential? xs) (first (drop-while ident? xs)))
@@ -1418,23 +1445,32 @@
 
           (map? first-xs)
           ;; [{:a 1 :b 2 :c 3}]
-          (let [[cols cols-sql]
-                (columns-from-values xs (or (contains-clause? :insert-into)
-                                            (contains-clause? :patch-into)
-                                            (contains-clause? :replace-into)
-                                            (contains-clause? :columns)))
+          (let [explicit (explicit-columns)
+                [cols cols-sql]
+                (if explicit
+                  ;; issue #613: an explicit column list (in :insert-into or
+                  ;; :columns) determines the order values are read from rows
+                  ;; and is rendered by that clause, not here:
+                  [explicit nil]
+                  (columns-from-values xs (or (contains-clause? :insert-into)
+                                              (contains-clause? :patch-into)
+                                              (contains-clause? :replace-into)
+                                              (contains-clause? :columns))))
                 [sqls params]
                 (reduce
                  (fn [[sql params] x]
                    (if (map? x)
                      (let [[sqls' params']
-                           (reduce-sql (map #(format-expr
-                                              (get x %
-                                                   ;; issue #366: use NULL or DEFAULT
-                                                   ;; for missing column values:
-                                                   (when (contains? values-default-columns %)
-                                                     [:default]))))
-                                       cols)]
+                           (reduce-sql (map (fn [col]
+                                              (let [rk (if explicit (row-key x col) col)]
+                                                (format-expr
+                                                 (get x rk
+                                                      ;; issue #366: use NULL or DEFAULT
+                                                      ;; for missing column values:
+                                                      (when (or (contains? values-default-columns col)
+                                                                (contains? values-default-columns rk))
+                                                        [:default])))))
+                                            cols))]
                        [(conj sql
                               (if (sequential? sqls')
                                 (str "(" (join ", " sqls') ")")

--- a/test/honey/sql/helpers_test.cljc
+++ b/test/honey/sql/helpers_test.cljc
@@ -514,8 +514,8 @@
 (deftest issue-293-sql
   ;; these tests are based on the README at https://github.com/nilenso/honeysql-postgres
   (is (= (-> (insert-into :distributors)
-             (values [{:did 5 :dname "Gizmo Transglobal"}
-                      {:did 6 :dname "Associated Computing, Inc"}])
+             (values [(array-map :did 5 :dname "Gizmo Transglobal")
+                      (array-map :did 6 :dname "Associated Computing, Inc")])
              (-> (on-conflict :did)
                  (do-update-set :dname))
              (returning :*)
@@ -528,11 +528,11 @@
           5 "Gizmo Transglobal"
           6 "Associated Computing, Inc"]))
   (is (= (-> (insert-into :distributors)
-             (values [{:did 23 :dname "Foo Distributors"}])
+             (values [(array-map :did 23 :dname "Foo Distributors")])
              (on-conflict :did)
              ;; instead of do-update-set!
-             (do-update-set {:dname [:|| :EXCLUDED.dname " (formerly " :distributors.dname ")"]
-                             :downer :EXCLUDED.downer})
+             (do-update-set (array-map :dname [:|| :EXCLUDED.dname " (formerly " :distributors.dname ")"]
+                                       :downer :EXCLUDED.downer))
              sql/format)
          [(str "INSERT INTO distributors (did, dname)"
                " VALUES (?, ?)"

--- a/test/honey/sql/postgres_test.cljc
+++ b/test/honey/sql/postgres_test.cljc
@@ -35,8 +35,8 @@
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?), (?, ?) ON CONFLICT (did) DO UPDATE SET dname = EXCLUDED.dname RETURNING *" 5 "Gizmo Transglobal" 6 "Associated Computing, Inc"]
            ;; preferred in honeysql:
            (-> (insert-into :distributors)
-               (values [{:did 5 :dname "Gizmo Transglobal"}
-                        {:did 6 :dname "Associated Computing, Inc"}])
+               (values [(array-map :did 5 :dname "Gizmo Transglobal")
+                        (array-map :did 6 :dname "Associated Computing, Inc")])
                (on-conflict :did)
                (do-update-set :dname)
                (returning :*)
@@ -44,8 +44,8 @@
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?), (?, ?) ON CONFLICT (did) DO UPDATE SET dname = EXCLUDED.dname RETURNING *" 5 "Gizmo Transglobal" 6 "Associated Computing, Inc"]
            ;; identical to nilenso version:
            (-> (insert-into :distributors)
-               (values [{:did 5 :dname "Gizmo Transglobal"}
-                        {:did 6 :dname "Associated Computing, Inc"}])
+               (values [(array-map :did 5 :dname "Gizmo Transglobal")
+                        (array-map :did 6 :dname "Associated Computing, Inc")])
                (upsert (-> (on-conflict :did)
                            (do-update-set :dname)))
                (returning :*)
@@ -53,70 +53,70 @@
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT (did) DO NOTHING" 7 "Redline GmbH"]
            ;; preferred in honeysql:
            (-> (insert-into :distributors)
-               (values [{:did 7 :dname "Redline GmbH"}])
+               (values [(array-map :did 7 :dname "Redline GmbH")])
                (on-conflict :did)
                do-nothing
                sql/format)))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT (did) DO NOTHING" 7 "Redline GmbH"]
            ;; identical to nilenso version:
            (-> (insert-into :distributors)
-               (values [{:did 7 :dname "Redline GmbH"}])
+               (values [(array-map :did 7 :dname "Redline GmbH")])
                (upsert (-> (on-conflict :did)
                            do-nothing))
                sql/format)))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT ON CONSTRAINT distributors_pkey DO NOTHING" 9 "Antwerp Design"]
            ;; preferred in honeysql:
            (-> (insert-into :distributors)
-               (values [{:did 9 :dname "Antwerp Design"}])
+               (values [(array-map :did 9 :dname "Antwerp Design")])
                (on-conflict (on-constraint :distributors_pkey))
                do-nothing
                sql/format)))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT (did) ON CONSTRAINT distributors_pkey DO NOTHING" 9 "Antwerp Design"]
            ;; with both name and clause:
            (-> (insert-into :distributors)
-               (values [{:did 9 :dname "Antwerp Design"}])
+               (values [(array-map :did 9 :dname "Antwerp Design")])
                (on-conflict :did (on-constraint :distributors_pkey))
                do-nothing
                sql/format)))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT (did, dname) ON CONSTRAINT distributors_pkey DO NOTHING" 9 "Antwerp Design"]
            ;; with multiple names and a clause:
            (-> (insert-into :distributors)
-               (values [{:did 9 :dname "Antwerp Design"}])
+               (values [(array-map :did 9 :dname "Antwerp Design")])
                (on-conflict :did :dname (on-constraint :distributors_pkey))
                do-nothing
                sql/format)))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT ON CONSTRAINT distributors_pkey DO NOTHING" 9 "Antwerp Design"]
            ;; almost identical to nilenso version:
            (-> (insert-into :distributors)
-               (values [{:did 9 :dname "Antwerp Design"}])
+               (values [(array-map :did 9 :dname "Antwerp Design")])
                ;; in nilenso, this was (on-conflict-constraint :distributors_pkey)
                (upsert (-> (on-conflict (on-constraint :distributors_pkey))
                            do-nothing))
                sql/format)))
     (is (= ["INSERT INTO foo (id, data) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET into = ((STATE(?), MODIFIED(NOW()))) WHERE state = ?" 1 42 "enabled" "disabled"]
            (sql/format (-> (insert-into :foo)
-                           (values [{:id 1 :data 42}])
+                           (values [(array-map :id 1 :data 42)])
                            (upsert (-> (on-conflict :id)
                                        (do-update-set [:state "enabled"]
                                                       [:modified [:now]])
                                        (where [:= :state "disabled"])))))))
     (is (= ["INSERT INTO foo (id, data) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET state = ?, modified = NOW() WHERE state = ?" 1 42 "enabled" "disabled"]
            (sql/format (-> (insert-into :foo)
-                           (values [{:id 1 :data 42}])
+                           (values [(array-map :id 1 :data 42)])
                            (upsert (-> (on-conflict :id)
-                                       (do-update-set {:state "enabled"
-                                                       :modified [:now]})
+                                       (do-update-set (array-map :state "enabled"
+                                                                 :modified [:now]))
                                        (where [:= :state "disabled"])))))))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?), (?, ?) ON CONFLICT (did) DO UPDATE SET dname = EXCLUDED.dname" 10 "Pinp Design" 11 "Foo Bar Works"]
            (sql/format {:insert-into :distributors
-                        :values [{:did 10 :dname "Pinp Design"}
-                                 {:did 11 :dname "Foo Bar Works"}]
+                        :values [(array-map :did 10 :dname "Pinp Design")
+                                 (array-map :did 11 :dname "Foo Bar Works")]
                         ;; in nilenso, these two were a submap under :upsert
                         :on-conflict :did
                         :do-update-set :dname})))
     (is (= ["INSERT INTO distributors (did, dname) VALUES (?, ?) ON CONFLICT (did) DO UPDATE SET dname = EXCLUDED.dname || ? || d.dname || ?" 23 "Foo Distributors" " (formerly " ")"]
            (-> (insert-into :distributors)
-               (values [{:did 23 :dname "Foo Distributors"}])
+               (values [(array-map :did 23 :dname "Foo Distributors")])
                (on-conflict :did)
                ;; nilenso:
                #_(do-update-set! [:dname "EXCLUDED.dname || ' (formerly ' || d.dname || ')'"])
@@ -143,7 +143,7 @@
   (is (= ["INSERT INTO user (phone, name) VALUES (?, ?) ON CONFLICT (phone) WHERE phone IS NOT NULL DO UPDATE SET phone = EXCLUDED.phone, name = EXCLUDED.name WHERE user.active = FALSE" "5555555" "John"]
          (sql/format
           {:insert-into :user
-           :values      [{:phone "5555555" :name "John"}]
+           :values      [(array-map :phone "5555555" :name "John")]
            :on-conflict   [:phone
                            {:where [:<> :phone nil]}]
            :do-update-set {:fields [:phone :name]
@@ -151,7 +151,7 @@
          ;; nilenso version
          #_(sql/format
             {:insert-into :user
-             :values      [{:phone "5555555" :name "John"}]
+             :values      [(array-map :phone "5555555" :name "John")]
              ;; nested under :upsert
              :upsert      {:on-conflict   [:phone]
                            ;; but :where is at the same level as :on-conflict
@@ -323,8 +323,8 @@
            (-> (insert-into :distributors :d)
                ;; nilensor required insert-into-as:
                #_(insert-into-as :distributors :d)
-               (values [{:did 5 :dname "Gizmo Transglobal"}
-                        {:did 6 :dname "Associated Computing, Inc"}])
+               (values [(array-map :did 5 :dname "Gizmo Transglobal")
+                        (array-map :did 6 :dname "Associated Computing, Inc")])
                (on-conflict :did)
                ;; honeysql supports names and a where clause:
                (do-update-set :dname (where [:<> :d.zipcode "21201"]))

--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -335,6 +335,54 @@
     (is (or (= res ["INSERT INTO foo (id, bar) VALUES (?, ?), (?, NULL)" 1 "quux" 2])
             (= res ["INSERT INTO foo (bar, id) VALUES (?, ?), (NULL, ?)" "quux" 1 2])))))
 
+(deftest issue-613-explicit-columns-with-map-rows
+  ;; when an explicit column list is given, values from map rows must be
+  ;; read in that column order, not in the row map's key order:
+  (testing ":columns clause"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:insert-into :t :columns [:did :dname]
+                        :values [(array-map :dname "Gizmo" :did 5)]})))
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:insert-into :t :columns [:did :dname]
+                        :values [(hash-map :dname "Gizmo" :did 5)]}))))
+  (testing "columns in :insert-into"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:insert-into [:t [:did :dname]]
+                        :values [(array-map :dname "Gizmo" :did 5)]})))
+    (is (= ["INSERT INTO t AS x (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:insert-into [[:t :x] [:did :dname]]
+                        :values [(array-map :dname "Gizmo" :did 5)]}))))
+  (testing ":insert-into columns take precedence over :columns"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:insert-into [:t [:did :dname]] :columns [:dname :did]
+                        :values [(array-map :dname "Gizmo" :did 5)]}))))
+  (testing "rows with differing key order"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?), (?, ?)" 5 "Gizmo" 7 "Redline"]
+           (sut/format {:insert-into :t :columns [:did :dname]
+                        :values [(array-map :dname "Gizmo" :did 5)
+                                 (array-map :did 7 :dname "Redline")]}))))
+  (testing "missing keys still get NULL or DEFAULT"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, NULL)" 5]
+           (sut/format {:insert-into :t :columns [:did :dname]
+                        :values [{:did 5}]})))
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, DEFAULT)" 5]
+           (sut/format {:insert-into :t :columns [:did :dname]
+                        :values [{:did 5}]}
+                       {:values-default-columns #{:dname}}))))
+  (testing "column names are matched to row keys by name when qualified"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:insert-into :t :columns [:did :dname]
+                        :values [(array-map :t/dname "Gizmo" :t/did 5)]}))))
+  (testing "symbol DSL"
+    (is (= ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format '{insert-into [t [did dname]]
+                         values [{dname "Gizmo" did 5}]}))))
+  (testing "replace-into"
+    (is (= ["REPLACE INTO `t` (`did`, `dname`) VALUES (?, ?)" 5 "Gizmo"]
+           (sut/format {:replace-into :t :columns [:did :dname]
+                        :values [(array-map :dname "Gizmo" :did 5)]}
+                       {:dialect :mysql})))))
+
 (deftest insert-into-functions
   ;; needs [[:raw ..]] because it's the columns case:
   (is (= (sut/format {:insert-into [[[:raw "My-Table Name"]] {:select [:bar] :from [:baz]}]})
@@ -921,8 +969,8 @@ ORDER BY id = ? DESC
         enabled [true, "); SELECT case when (SELECT current_setting('is_superuser'))='off' then pg_sleep(0.2) end; -- "]]
     (is (= ["INSERT INTO table (name, enabled) VALUES (?, (TRUE, ?))" name (second enabled)]
            (sut/format {:insert-into :table
-                        :values [{:name name
-                                  :enabled enabled}]})))))
+                        :values [(array-map :name name
+                                            :enabled enabled)]})))))
 
 (deftest issue-425-default-values-test
   (testing "default values"
@@ -941,12 +989,12 @@ ORDER BY id = ? DESC
   (testing "map values with default row, no columns"
     (is (= ["INSERT INTO table (a, b, c) VALUES (1, 2, 3), DEFAULT, (4, 5, 6)"]
            (sut/format {:insert-into :table
-                        :values [{:a 1 :b 2 :c 3} :default {:a 4 :b 5 :c 6}]}
+                        :values [(array-map :a 1 :b 2 :c 3) :default (array-map :a 4 :b 5 :c 6)]}
                        {:inline true}))))
   (testing "map values with default column, no columns"
     (is (= ["INSERT INTO table (a, b, c) VALUES (1, DEFAULT, 3), DEFAULT"]
            (sut/format {:insert-into :table
-                        :values [{:a 1 :b [:default] :c 3} :default]}
+                        :values [(array-map :a 1 :b [:default] :c 3) :default]}
                        {:inline true}))))
   (testing "empty values"
     (is (= ["INSERT INTO table (a, b, c) VALUES ()"]
@@ -1426,7 +1474,7 @@ ORDER BY id = ? DESC
                       :values [[1 2]]})))
   (is (= ["INSERT INTO table (a, b) OVERRIDING SYSTEM VALUE VALUES (?, ?)" 1 2]
          (sut/format {:insert-into [{:overriding-value :system} :table]
-                      :values [{:a 1 :b 2}]}))))
+                      :values [(array-map :a 1 :b 2)]}))))
 
 (deftest issue-497-alias
 


### PR DESCRIPTION
Fixes #613.

## Problem

When an explicit column list is given together with hash map rows in `:values`, the column names were rendered from the explicit list but the values were still read in the first row map's key order. If the two orders differed, values silently landed in the wrong columns:

```clojure
(sql/format {:insert-into :t :columns [:did :dname]
             :values [(array-map :dname "Gizmo" :did 5)]})
;; before: ["INSERT INTO t (did, dname) VALUES (?, ?)" "Gizmo" 5]
;; after:  ["INSERT INTO t (did, dname) VALUES (?, ?)" 5 "Gizmo"]
```

Separately, eight tests asserted on the iteration order of literal hash maps, which only holds on JVM Clojure and ClojureScript by accident of `PersistentArrayMap`, not by language guarantee.

## Changes

- `format-values`: when an explicit column list exists (from `:insert-into` / `:patch-into` / `:replace-into` table spec, taking precedence over a `:columns` clause), use it to read values from each row. Keys are matched exactly, then by name so `:t/did` satisfies `:did`. Missing keys keep the existing `NULL` / `DEFAULT` handling from #366. With no explicit column list, behaviour is unchanged.
- Tests: new `issue-613-explicit-columns-with-map-rows` covering `:columns`, columns in `:insert-into` (with and without alias), precedence, multiple rows with differing key order, `NULL` / `DEFAULT` for missing keys, qualified row keys, the symbol DSL, and `:replace-into`. All 11 assertions fail on `develop` and pass with this change.
- Tests: the 23 multi-key literal maps in the 8 order-dependent tests now use `array-map`, matching the existing `test-value` test.
- Docs: caveat under `:values` (with a doc-tested example) and `:set` about hash map iteration order.
- Changelog entry.

## Verification

| Suite | Result |
|---|---|
| `clojure -X:test` | 178 tests, 2852 assertions, 0 failures |
| `bb test cljs` | 170 tests, 820 assertions, 0 failures |
| `bb doc-test` | 255 tests, 445 assertions, 0 failures |
