### PR TITLE
Fix three gaps in the existing `:lg` (let-go) support

### DIFF
--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -1459,7 +1459,7 @@
   ,)
 
 (defn- format-simple-expr [e context]
-  (#?(:clj with-inline :default binding) [*inline* true]
+  (#?(:lg binding :clj with-inline :default binding) [*inline* true]
     (let [[sql & params] (format-expr e)]
       (when (seq params)
         (throw (ex-info (str "parameters are not accepted in " context)
@@ -1538,7 +1538,7 @@
           [(str (sql-kw k) " " e " = EXCLUDED." e)])))
 
 (defn- format-simple-clause [c context]
-  (#?(:clj with-inline :default binding) [*inline* true]
+  (#?(:lg binding :clj with-inline :default binding) [*inline* true]
     (let [[sql & params] (format-dsl c)]
       (when (seq params)
         (throw (ex-info (str "parameters are not accepted in " context)
@@ -1788,7 +1788,7 @@
           (into* [(str (sql-kw k) " " sql " "
                        (join " " (map sql-kw) units))]
                  params))
-        (#?(:clj with-inline :default binding) [*inline* true]
+        (#?(:lg binding :clj with-inline :default binding) [*inline* true]
           (let [[sql & params] (format-expr n)]
             (into* [(str (sql-kw k) " " sql)] params)))))
     [(str (sql-kw k) " " (sql-kw args))]))
@@ -2268,7 +2268,7 @@
     (fn [_ [expr tz]]
       (let [[sql & params] (format-expr expr {:nested true})
             [tz-sql & _]
-            (#?(:clj with-inline :default binding) [*inline* true]
+            (#?(:lg binding :clj with-inline :default binding) [*inline* true]
               (format-expr (if (ident? tz) (name tz) tz)))]
         (into* [(str sql " AT TIME ZONE " tz-sql)] params)))
     :between     between-fn
@@ -2301,7 +2301,7 @@
     :ignore-nulls ignore-respect-nulls
     :inline
     (fn [_ xs]
-      (#?(:clj with-inline :default binding) [*inline* true]
+      (#?(:lg binding :clj with-inline :default binding) [*inline* true]
         [(join " " (mapcat #(format-expr % {:record true})) xs)]))
     :interval format-interval
     :join

--- a/src/honey/sql.cljc
+++ b/src/honey/sql.cljc
@@ -525,7 +525,11 @@
 
 (defn- inline-str [s]
   (if (or (mysql?) (not (:standard-conforming-strings *options*))) ; per #607: only apply special handling for MySQL dialect
-    (str \' (str/replace s #?(:lg "'" :default #"(?<!\\)'") "''") \')
+    ;; :lg -- Go's re2 has no lookbehind, so match \' as a unit and leave it
+    ;; alone instead, which only lets bare quotes reach the replacement:
+    (str \' #?(:lg (str/replace s #"\\'|'" (fn [m] (if (= m "'") "''" m)))
+               :default (str/replace s #"(?<!\\)'" "''"))
+         \')
     (str \' (str/replace s "'" "''") \')))
 
 (extend-protocol p/InlineValue

--- a/test/honey/sql_test.cljc
+++ b/test/honey/sql_test.cljc
@@ -1409,7 +1409,8 @@ ORDER BY id = ? DESC
     (is (= ["INNER JOIN (tbl1 LEFT JOIN tbl2 USING (id))"]
            (sut/format {:join [[[:join :tbl1 {:left-join [:tbl2 [:using :id]]}]]]})))))
 
-#?(:clj
+#?(:lg ()
+   :clj
    (deftest issue-495-formatv
      (is (= ["SELECT * FROM foo WHERE x = ?" 13]
             (let [v 13 x 42]


### PR DESCRIPTION
All three changes are related to `:lg` reader-conditional branches. `:clj` and `:default` are untouched, and the JVM suite is unchanged before and after (177 tests, 2841 assertions, 0 failures). Under [let-go](https://github.com/nooga/let-go) the suite goes from "nothing loads" to 173 tests, 769 assertions, 0 failures.

**1. `with-inline` stops `honey.sql` compiling.** Added in #609 (on `develop` only), it is defined `#?(:clj ...)` and selected with `#?(:clj with-inline :default binding)`. let-go matches `:clj`, so it takes `with-inline`, whose expansion needs `push-thread-bindings` / `pop-thread-bindings`. let-go has neither, so nothing loads at all. Fixed by routing `:lg` to `binding` at the five call sites, which is what `:default` already does and is semantically equivalent, since `with-inline` is a performance shortcut rather than a behaviour change.

**2. `issue-495-formatv` is not gated for `:lg`.** `formatv` is deliberately `:lg`-disabled in src, but the test is gated on `:clj` alone, so let-go reads a test for an undefined macro and `honey.sql-test` fails to compile with `Can't resolve sut/formatv`. Fixed by gating the test the same way src gates the macro.

**3. `inline-str` doubles already-escaped quotes.** Under MySQL and `{:standard-conforming-strings false}`, `\'` is already an escaped quote and must not be doubled. `:default` handles that with the lookbehind `#"(?<!\\)'"`. Go's re2 has no lookbehind, so `:lg` used a plain `"'"` and doubled everything, causing 8 failures in those two dialects. Fixed with an alternation that consumes `\'` as a unit, so only bare quotes reach the replacement:

```clojure
(str \' #?(:lg (str/replace s #"\\'|'" (fn [m] (if (= m "'") "''" m)))
           :default (str/replace s #"(?<!\\)'" "''"))
     \')
```

### Reproducing

Needs let-go built from `main` (the host-interop fixes honeysql relies on landed after `v1.12.2`) and [lgx](https://github.com/abogoyavlensky/lgx) 0.2.0 or newer:

```
cd honeysql && LGX_LG=/path/to/let-go/bin/lg lgx test
```

### The suite runs partially

10 of the 12 test namespaces run. Two do not load, for reasons outside HoneySQL, and fail identically before and after this change:

- `honey.cache-test` needs `core.cache`, which loads `data.priority-map`, which uses the `(. obj method args)` dot form let-go does not support.
- `honey.sql-alphanumeric-test` needs `test.check`, which needs `Long/bitCount` and the `Math/*` statics let-go does not have.

Both are let-go gaps being tracked separately. No new tests here: the 8 assertions that currently fail already cover the `inline-str` case.